### PR TITLE
feat: add new learning graph nodes

### DIFF
--- a/content/nodes/custody.cold-storage.json
+++ b/content/nodes/custody.cold-storage.json
@@ -1,0 +1,45 @@
+{
+  "id": "custody.cold-storage",
+  "title": "Cold Storage",
+  "description": "A custody model that keeps spending keys offline while using an online or watch-only system to monitor balances and prepare unsigned transactions. Cold storage reduces remote attack exposure but shifts more responsibility to backups, recovery procedures, and secure offline signing.",
+  "category": "Wallets",
+  "prerequisites": [
+    "custody.air-gapped-signing"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Wiki: Cold storage",
+      "url": "https://en.bitcoin.it/wiki/Cold_storage",
+      "notes": "Overview of offline key custody, watch-only monitoring, and transaction transfer workflows."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Design: Private Key Management",
+      "url": "https://bitcoin.design/guide/how-it-works/private-key-management/overview/",
+      "notes": "Threat-model and UX guidance for separating key storage, transaction preparation, and signing."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Broad reference for wallet security, private-key handling, backups, and offline signing.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "custody",
+    "security",
+    "wallets"
+  ],
+  "aliases": [
+    "cold storage",
+    "cold wallet",
+    "offline wallet storage",
+    "offline key storage"
+  ]
+}
+

--- a/content/nodes/custody.deterministic-multisig-key-sorting.json
+++ b/content/nodes/custody.deterministic-multisig-key-sorting.json
@@ -1,0 +1,46 @@
+{
+  "id": "custody.deterministic-multisig-key-sorting",
+  "title": "Deterministic Multisig Key Sorting",
+  "description": "The BIP 67 convention for sorting compressed public keys before constructing a multisig redeem script, so independent wallets derive the same script and address from the same signer set.",
+  "category": "Wallets",
+  "prerequisites": [
+    "custody.multisig",
+    "protocol.pay-to-script-hash"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 67: Deterministic Public Key Sorting",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki",
+      "notes": "Canonical specification for sorting compressed public keys in multisig scripts."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Multisig Tutorial",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/multisig-tutorial.md",
+      "notes": "Implementation-oriented context for multisig script construction and wallet interoperability."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for public keys, multisig scripts, and wallet interoperability.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "25m",
+  "tags": [
+    "wallets",
+    "multisig",
+    "standards",
+    "interoperability"
+  ],
+  "aliases": [
+    "BIP 67",
+    "sorted multisig keys",
+    "deterministic multisig"
+  ]
+}
+

--- a/content/nodes/custody.proof-of-reserves.json
+++ b/content/nodes/custody.proof-of-reserves.json
@@ -1,0 +1,46 @@
+{
+  "id": "custody.proof-of-reserves",
+  "title": "Proof of Reserves",
+  "description": "Proof of Reserves lets a custodian demonstrate control of a stated set or amount of Bitcoin at a point in time using a verifiable signed construction. It can provide evidence of asset control, but does not by itself prove liabilities, solvency, or that funds will remain available.",
+  "category": "Wallets",
+  "prerequisites": [
+    "custody.psbt",
+    "protocol.generic-signed-messages"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 127: Simple Proof-of-Reserves Transactions",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0127.mediawiki",
+      "notes": "Canonical specification for a standardized proof format and its PSBT extension. It documents privacy and scope limitations."
+    },
+    {
+      "type": "article",
+      "title": "Provisions: Privacy-Preserving Proofs of Solvency for Bitcoin Exchanges",
+      "url": "https://eprint.iacr.org/2015/1008",
+      "notes": "Research context for proving solvency with stronger privacy properties than simple control-of-funds proofs."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background on Bitcoin transactions, signatures, UTXOs, and wallet control that supports understanding reserve proofs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "custody",
+    "solvency",
+    "psbt",
+    "signatures"
+  ],
+  "aliases": [
+    "proof of reserves",
+    "proof-of-reserves transactions",
+    "PoR"
+  ]
+}
+

--- a/content/nodes/dev.bootstrappable-builds.json
+++ b/content/nodes/dev.bootstrappable-builds.json
@@ -1,0 +1,32 @@
+{
+  "id": "dev.bootstrappable-builds",
+  "title": "Bootstrappable Builds",
+  "description": "Bootstrappable builds reduce the trusted computing base by making the toolchain rebuildable from a small, independently verifiable set of binaries and source code. They strengthen reproducible builds by addressing trust in the compilers and build tools used to produce the final software.",
+  "category": "Security",
+  "prerequisites": ["dev.reproducible-builds"],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Development Philosophy: Bootstrappable Toolchains",
+      "url": "https://bitcoindevphilosophy.com/#trustlessness",
+      "notes": "Explains why reproducibility alone does not remove trust in prebuilt compilers and how a minimal trusted binary can bootstrap the toolchain."
+    },
+    {
+      "type": "article",
+      "title": "Guix: Bitcoin Core Build System",
+      "url": "https://github.com/bitcoin/bitcoin/tree/master/contrib/guix",
+      "notes": "Concrete build-system context for bootstrappable and reproducible Bitcoin Core builds."
+    },
+    {
+      "type": "book",
+      "title": "Bitcoin Development Philosophy",
+      "url": "https://amzn.to/4s33eUd",
+      "notes": "Long-form discussion of minimizing trusted binaries and verifying the build path.",
+      "regionalUrls": {"BR": "https://amzn.to/4uRjb1v"}
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": ["builds", "supply chain", "toolchains", "verification"],
+  "aliases": ["bootstrappable toolchains", "bootstrapable builds", "trust-minimized builds"]
+}
+

--- a/content/nodes/dev.permissionless-development.json
+++ b/content/nodes/dev.permissionless-development.json
@@ -1,0 +1,32 @@
+{
+  "id": "dev.permissionless-development",
+  "title": "Permissionless Development",
+  "description": "Permissionless development means people can build wallets, protocols, tools, and services around Bitcoin without asking a central authority for approval. The permissionless boundary is constrained by the protocol's rules and users' voluntary adoption, not by a developer committee granting access.",
+  "category": "History & Governance",
+  "prerequisites": ["fundamentals.neutrality", "dev.bips-process"],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Development Philosophy: Permissionless Development",
+      "url": "https://bitcoindevphilosophy.com/#permissionlessdevelopment",
+      "notes": "Explains permissionless participation by users, miners, and developers."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Development Philosophy: Neutrality",
+      "url": "https://bitcoindevphilosophy.com/#neutrality",
+      "notes": "Provides the adjacent protocol-neutrality context."
+    },
+    {
+      "type": "book",
+      "title": "Bitcoin Development Philosophy",
+      "url": "https://amzn.to/4s33eUd",
+      "notes": "Long-form context for permissionless participation and development norms.",
+      "regionalUrls": {"BR": "https://amzn.to/4uRjb1v"}
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": ["development", "governance", "neutrality", "open-source"],
+  "aliases": ["permissionless development", "permissionless building", "permissionless innovation"]
+}
+

--- a/content/nodes/dev.pseudonymous-development.json
+++ b/content/nodes/dev.pseudonymous-development.json
@@ -1,0 +1,15 @@
+{
+  "id":"dev.pseudonymous-development",
+  "title":"Pseudonymous Development",
+  "description":"Pseudonymous development lets Bitcoin contributors publish and review work without tying it to a legal identity. It can protect contributors from coercion while keeping technical claims accountable through public evidence and peer review.",
+  "category":"History & Governance",
+  "prerequisites":["dev.review-culture"],
+  "resources":[
+    {"type":"article","title":"Bitcoin Development Philosophy: Pseudonymous Development","url":"https://bitcoindevphilosophy.com/#pseudonymousdevelopment","notes":"Explains why contributor pseudonymity can support merit-based evaluation and personal safety."},
+    {"type":"book","title":"Bitcoin Development Philosophy","url":"https://amzn.to/4s33eUd","notes":"Long-form context for open-source development, review, and contributor safety.","regionalUrls":{"BR":"https://amzn.to/4uRjb1v"}}
+  ],
+  "estimatedTime":"25m",
+  "tags":["development","privacy","open-source","governance"],
+  "aliases":["pseudonymous contributors","developer pseudonymity"]
+}
+

--- a/content/nodes/dev.review-culture.json
+++ b/content/nodes/dev.review-culture.json
@@ -1,0 +1,44 @@
+{
+  "id": "dev.review-culture",
+  "title": "Review Culture in Bitcoin Development",
+  "description": "Bitcoin development relies on independent, adversarial peer review and incremental discussion to catch correctness, security, and compatibility failures before changes are merged.",
+  "category": "History & Governance",
+  "prerequisites": [
+    "dev.bips-process",
+    "security.adversarial-thinking"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Development Philosophy: Review",
+      "url": "https://bitcoindevphilosophy.com/#review",
+      "notes": "Explains the layers of conceptual, proposal, implementation, deployment, and user-adoption review."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Contributing Guide",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md",
+      "notes": "Practical expectations for proposing, reviewing, testing, and iterating on Bitcoin Core changes."
+    },
+    {
+      "type": "book",
+      "title": "Bitcoin Development Philosophy",
+      "url": "https://amzn.to/4s33eUd",
+      "notes": "Broader context for why independent review, restraint, and incremental consensus matter in Bitcoin development.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4uRjb1v"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "development",
+    "review",
+    "security"
+  ],
+  "aliases": [
+    "Bitcoin development review",
+    "code review in Bitcoin"
+  ]
+}
+

--- a/content/nodes/dev.selection-cryptography.json
+++ b/content/nodes/dev.selection-cryptography.json
@@ -1,0 +1,36 @@
+{
+  "id": "dev.selection-cryptography",
+  "title": "Selection Cryptography",
+  "description": "Selection cryptography is the practice of choosing cryptographic libraries, tools, and practices suitable for Bitcoin software by assessing their review, testing, portability, and dependency risk.",
+  "category": "History & Governance",
+  "prerequisites": [
+    "dev.review-culture"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Development Philosophy: Selection Cryptography",
+      "url": "https://bitcoindevphilosophy.com/#selectioncryptography",
+      "notes": "Explains the decision process for choosing cryptographic tools, libraries, and practices in Bitcoin systems."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Dependencies",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md",
+      "notes": "Concrete project guidance for understanding and minimizing third-party dependency exposure."
+    },
+    {
+      "type": "book",
+      "title": "Bitcoin Development Philosophy",
+      "url": "https://amzn.to/4s33eUd",
+      "notes": "Long-form treatment of reviewing cryptographic choices and minimizing dependency risk in Bitcoin software.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4uRjb1v"
+      }
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": ["development", "cryptography", "dependencies", "security", "review"],
+  "aliases": ["cryptographic dependency selection", "choosing cryptographic libraries", "crypto library due diligence"]
+}
+

--- a/content/nodes/dev.submitpackage-rpc.json
+++ b/content/nodes/dev.submitpackage-rpc.json
@@ -1,0 +1,52 @@
+{
+  "id": "dev.submitpackage-rpc",
+  "title": "submitpackage RPC",
+  "description": "Bitcoin Core's submitpackage RPC submits a topologically ordered package of raw transactions to the local mempool for consensus and package-policy evaluation; local acceptance does not imply network propagation.",
+  "category": "Network, Relay & Client Sync",
+  "prerequisites": [
+    "dev.testmempoolaccept-rpc"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Core 31.0 submitpackage RPC",
+      "url": "https://bitcoincore.org/en/doc/31.0.0/rpc/rawtransactions/submitpackage/",
+      "notes": "Current RPC reference for submitting packages, interpreting admission results, and understanding the local-only propagation boundary."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Package Mempool Acceptance Policy",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/policy/packages.md",
+      "notes": "Canonical package topology, limits, fee-rate, replacement, and submission-policy rules."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core 26.0 Release Notes",
+      "url": "https://bitcoincore.org/en/releases/26.0/",
+      "notes": "Historical introduction of submitpackage and its package-CPFP use case before package relay support."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for RPC workflows, mempool admission, transaction packages, and fee-bumping behavior.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "rpc",
+    "mempool",
+    "packages",
+    "fee-bumping"
+  ],
+  "aliases": [
+    "submitpackage",
+    "submitpackage RPC",
+    "local package submission",
+    "package mempool submission"
+  ]
+}
+

--- a/content/nodes/economics.bitcoin-denominations.json
+++ b/content/nodes/economics.bitcoin-denominations.json
@@ -1,0 +1,38 @@
+{
+  "id": "economics.bitcoin-denominations",
+  "title": "Bitcoin Denominations and Satoshis",
+  "description": "Bitcoin is commonly expressed in BTC and satoshis. One bitcoin contains 100 million satoshis, making the satoshi the smallest standard unit used to quote and transfer bitcoin amounts.",
+  "category": "Economics & Incentives",
+  "prerequisites": [
+    "fundamentals.money-properties"
+  ],
+  "resources": [
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Foundational reference for bitcoin units, amounts, and transaction representation.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Developer Guide: Transactions",
+      "url": "https://developer.bitcoin.org/devguide/transactions.html",
+      "notes": "Technical context for integer-denominated transaction amounts."
+    }
+  ],
+  "estimatedTime": "20m",
+  "tags": [
+    "money",
+    "units",
+    "satoshis"
+  ],
+  "aliases": [
+    "sats",
+    "bitcoin units",
+    "BTC denominations"
+  ]
+}
+

--- a/content/nodes/economics.block-subsidy.json
+++ b/content/nodes/economics.block-subsidy.json
@@ -1,0 +1,38 @@
+{
+  "id": "economics.block-subsidy",
+  "title": "Block Subsidy",
+  "description": "The block subsidy is the newly issued bitcoin a valid block may claim in its coinbase transaction. It follows the issuance schedule and declines through halvings, while transaction fees are a separate part of miner revenue.",
+  "category": "Economics & Incentives",
+  "prerequisites": [
+    "protocol.coinbase-transaction"
+  ],
+  "resources": [
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Reference for mining rewards, coinbase transactions, and Bitcoin's issuance schedule.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Developer Guide: Block Chain",
+      "url": "https://developer.bitcoin.org/devguide/block_chain.html",
+      "notes": "Explains block validation and the coinbase reward."
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": [
+    "issuance",
+    "mining",
+    "monetary-policy"
+  ],
+  "aliases": [
+    "mining subsidy",
+    "block reward subsidy",
+    "new bitcoin issuance"
+  ]
+}
+

--- a/content/nodes/extension.client-side-validation.json
+++ b/content/nodes/extension.client-side-validation.json
@@ -1,0 +1,16 @@
+{
+  "id": "extension.client-side-validation",
+  "title": "Client-Side Validation",
+  "description": "Client-side validation lets the recipient validate an offchain asset's transition history and contract rules, using Bitcoin UTXOs as single-use seals instead of asking full nodes to enforce the asset's state.",
+  "category": "Extension Systems",
+  "prerequisites": ["extension.single-use-seals", "protocol.pay-to-contract"],
+  "resources": [
+    {"type":"article","title":"Mastering Bitcoin: Applications","url":"https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch14_applications.adoc","notes":"Describes client-side validation, single-use seals, and recipient verification for application-layer assets."},
+    {"type":"article","title":"Bitcoin Optech: Client-Side Validation","url":"https://bitcoinops.org/en/topics/client-side-validation/","notes":"Terminology and current ecosystem context for validation performed by asset participants rather than Bitcoin full nodes."},
+    {"type":"book","title":"Mastering Bitcoin","url":"https://amzn.to/4ro0NdG","notes":"Long-form treatment of UTXOs and application-layer protocols.","regionalUrls":{"BR":"https://amzn.to/4te47JX"}}
+  ],
+  "estimatedTime":"40m",
+  "tags":["assets","validation","utxos","contracts","rgb"],
+  "aliases":["recipient-side validation","client validated assets","single-use seals"]
+}
+

--- a/content/nodes/extension.cross-chain-bridges.json
+++ b/content/nodes/extension.cross-chain-bridges.json
@@ -1,0 +1,36 @@
+{
+  "id": "extension.cross-chain-bridges",
+  "title": "Cross-Chain Bridges",
+  "description": "Cross-chain bridges move or represent assets between Bitcoin and other networks using custodians, federations, multisig committees, light-client proofs, or cryptographic verification. Their security depends on the bridge mechanism rather than Bitcoin alone.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.sidechains"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Layer Two Resources",
+      "url": "https://www.lopp.net/bitcoin-information/other-layers.html",
+      "notes": "Curated overview of bridge designs including Interlay, Threshold, and Wrapped Bitcoin."
+    },
+    {
+      "type": "article",
+      "title": "Interlay",
+      "url": "https://www.interlay.io/",
+      "notes": "Example of a trust-minimized cross-chain Bitcoin bridge design."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin transactions, multisig, and cross-system trust assumptions.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "55m",
+  "tags": ["bridges", "cross-chain", "sidechains", "custody"],
+  "aliases": ["Bitcoin bridges", "cross-chain bridge security"]
+}
+

--- a/content/nodes/extension.cube.json
+++ b/content/nodes/extension.cube.json
@@ -1,0 +1,37 @@
+{
+  "id": "extension.cube",
+  "title": "Cube",
+  "description": "Cube is a Bitcoin-native Layer 2 and virtual machine for trustless smart-contract execution. It combines ZKTLCs, timeout-tree exits, and Bitcoin data availability so users can retain unilateral control without a trusted custodian.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.zktlcs"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Cube Bitcoin Repository",
+      "url": "https://github.com/cube-btc/cube",
+      "notes": "Primary implementation repository for Cube's Bitcoin-native execution environment."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin's transaction, Script, custody, and settlement model.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "90m",
+  "tags": [
+    "bitcoin-l2",
+    "smart-contracts",
+    "virtual-machine",
+    "self-custody"
+  ],
+  "aliases": [
+    "Cube Bitcoin",
+    "CubeVM"
+  ]
+}

--- a/content/nodes/extension.drivechains.json
+++ b/content/nodes/extension.drivechains.json
@@ -1,0 +1,37 @@
+{
+  "id": "extension.drivechains",
+  "title": "Drivechains",
+  "description": "Drivechains are a sidechain design that uses blind merged mining and a miner-mediated withdrawal mechanism to move value between Bitcoin and an auxiliary chain. The design trades federation trust for miner governance and new consensus assumptions.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.sidechains",
+    "mining.merge-mining"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Drivechain Information",
+      "url": "https://www.drivechain.info/",
+      "notes": "Primary overview of the drivechain proposal and its miner-mediated peg model."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Layer Two Resources",
+      "url": "https://www.lopp.net/bitcoin-information/other-layers.html",
+      "notes": "Curated context for drivechains among Bitcoin layer designs."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for sidechains, mining, and Bitcoin settlement.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "50m",
+  "tags": ["bitcoin-l2", "sidechains", "merged-mining", "peg"],
+  "aliases": ["drivechain", "drivechains"]
+}
+

--- a/content/nodes/extension.elements.json
+++ b/content/nodes/extension.elements.json
@@ -1,0 +1,44 @@
+{
+  "id": "extension.elements",
+  "title": "Elements Platform",
+  "description": "Elements is an open-source Bitcoin-derived blockchain platform for building sidechains and application-specific networks. It extends Bitcoin-style transactions with features such as confidential transactions, issued assets, and federation-based interoperability.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.sidechains"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Elements Project",
+      "url": "https://elementsproject.org/",
+      "notes": "Project overview and platform capabilities."
+    },
+    {
+      "type": "article",
+      "title": "Elements Repository",
+      "url": "https://github.com/ElementsProject/elements",
+      "notes": "Reference implementation for Elements-based networks."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin-derived chains, transactions, and Script.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "60m",
+  "tags": [
+    "elements",
+    "sidechains",
+    "confidential-transactions",
+    "assets"
+  ],
+  "aliases": [
+    "Elements blockchain platform",
+    "Elements Core"
+  ]
+}
+

--- a/content/nodes/extension.liquid.json
+++ b/content/nodes/extension.liquid.json
@@ -1,0 +1,48 @@
+{
+  "id": "extension.liquid",
+  "title": "Liquid Network",
+  "description": "Liquid is a production Bitcoin sidechain built on the Elements platform. It uses a federation and two-way peg for Bitcoin movement, supports confidential transactions and issued assets, and provides faster settlement with Lightning interoperability.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.elements",
+    "protocol.confidential-transactions"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Liquid Developer Documentation",
+      "url": "https://docs.liquid.net/docs/welcome-to-liquid-developer-documentation-portal",
+      "notes": "Official documentation for Liquid architecture, applications, and development."
+    },
+    {
+      "type": "article",
+      "title": "How Liquid Works",
+      "url": "https://docs.liquid.net/docs/how-liquid-works",
+      "notes": "Explains Liquid's Elements-based node, federation, transactions, and network flow."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for sidechains, Bitcoin transactions, and layer architecture.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "75m",
+  "tags": [
+    "liquid",
+    "sidechains",
+    "elements",
+    "assets",
+    "confidential-transactions",
+    "lightning"
+  ],
+  "aliases": [
+    "Liquid Network",
+    "Liquid sidechain",
+    "L-BTC"
+  ]
+}
+

--- a/content/nodes/extension.ordinals-inscriptions.json
+++ b/content/nodes/extension.ordinals-inscriptions.json
@@ -1,0 +1,39 @@
+{
+  "id": "extension.ordinals-inscriptions",
+  "title": "Ordinals and Inscriptions",
+  "description": "Ordinals assign an ordering identity to individual satoshis, while inscriptions attach arbitrary witness data to transactions. Together they create a Bitcoin application pattern for collectibles and other data-bearing artifacts with on-chain fee and block-space tradeoffs.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "protocol.taproot",
+    "protocol.witness-structure"
+  ],
+  "resources": [
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin transactions, SegWit witness data, and Taproot script paths.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    },
+    {
+      "type": "article",
+      "title": "Ordinals Protocol",
+      "url": "https://docs.ordinals.com/",
+      "notes": "Protocol documentation for ordinal theory and inscriptions."
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "taproot",
+    "witness",
+    "applications"
+  ],
+  "aliases": [
+    "Ordinals",
+    "Bitcoin inscriptions",
+    "ordinal inscriptions"
+  ]
+}
+

--- a/content/nodes/extension.proof-of-existence.json
+++ b/content/nodes/extension.proof-of-existence.json
@@ -1,0 +1,44 @@
+{
+  "id": "extension.proof-of-existence",
+  "title": "Proof of Existence and Timestamping",
+  "description": "Proof-of-existence protocols commit evidence to Bitcoin so anyone can later verify that a document or statement existed no later than a particular time, without storing the entire document on-chain.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "fundamentals.commitment-schemes"
+  ],
+  "resources": [
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for hashes, commitments, transactions, and Bitcoin data anchoring.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    },
+    {
+      "type": "article",
+      "title": "OpenTimestamps",
+      "url": "https://opentimestamps.org/",
+      "notes": "Open protocol and implementation for decentralized timestamp proofs."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Genesis Block",
+      "url": "https://developer.bitcoin.org/reference/block_chain.html",
+      "notes": "Historical example of a time-bound message embedded in Bitcoin's launch block."
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "commitments",
+    "timestamping",
+    "applications"
+  ],
+  "aliases": [
+    "proof of existence",
+    "Bitcoin timestamping",
+    "OpenTimestamps"
+  ]
+}
+

--- a/content/nodes/extension.rgb.json
+++ b/content/nodes/extension.rgb.json
@@ -1,0 +1,45 @@
+{
+  "id": "extension.rgb",
+  "title": "RGB Protocol",
+  "description": "RGB is a client-side-validated smart-contract protocol for Bitcoin and Lightning. It keeps contract state and validation data off-chain, anchors commitments to Bitcoin transaction outputs, and lets participants validate the asset history they receive without requiring Bitcoin consensus changes.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.client-side-validation"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "RGB Documentation",
+      "url": "https://rgb.tech/docs/",
+      "notes": "Official documentation for RGB concepts, standards, contracts, and integration."
+    },
+    {
+      "type": "article",
+      "title": "RGB Protocol Repository",
+      "url": "https://github.com/RGB-WG/rgb",
+      "notes": "Reference implementation and wallet/runtime integration code."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin transactions, commitments, UTXOs, and application-layer protocols.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "75m",
+  "tags": [
+    "rgb",
+    "client-side-validation",
+    "smart-contracts",
+    "assets",
+    "lightning"
+  ],
+  "aliases": [
+    "RGB smart contracts",
+    "RGB protocol"
+  ]
+}
+

--- a/content/nodes/extension.rollups.json
+++ b/content/nodes/extension.rollups.json
@@ -1,0 +1,37 @@
+{
+  "id": "extension.rollups",
+  "title": "Bitcoin Rollups",
+  "description": "Bitcoin rollups execute transactions or contracts off-chain and commit compressed state data or validity evidence to Bitcoin. They aim to scale execution while inheriting selected settlement or verification guarantees from the base layer.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "fundamentals.zero-knowledge-proofs",
+    "extension.sidechains"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Rollups",
+      "url": "https://bitcoinrollups.org/",
+      "notes": "Dedicated overview of validity-rollup designs for Bitcoin."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Layer Two Resources",
+      "url": "https://www.lopp.net/bitcoin-information/other-layers.html",
+      "notes": "Curated entry point to rollups and related Bitcoin layers."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin settlement, transactions, and layer architecture.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "60m",
+  "tags": ["bitcoin-l2", "rollups", "zero-knowledge", "scaling"],
+  "aliases": ["Bitcoin rollup", "validity rollups"]
+}
+

--- a/content/nodes/extension.single-use-seals.json
+++ b/content/nodes/extension.single-use-seals.json
@@ -1,0 +1,15 @@
+{
+  "id":"extension.single-use-seals",
+  "title":"Single-Use Seals",
+  "description":"A single-use seal binds an offchain state transition to a UTXO that can be spent only once. Spending the outpoint closes the old seal and prevents the same state transition from being valid twice.",
+  "category":"Extension Systems",
+  "prerequisites":["protocol.utxo-model"],
+  "resources":[
+    {"type":"article","title":"Mastering Bitcoin: Applications","url":"https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch14_applications.adoc","notes":"Explains how Bitcoin outpoints provide single-use seals for client-side validated systems."},
+    {"type":"book","title":"Mastering Bitcoin","url":"https://amzn.to/4ro0NdG","notes":"Background on UTXOs and application-layer protocols.","regionalUrls":{"BR":"https://amzn.to/4te47JX"}}
+  ],
+  "estimatedTime":"25m",
+  "tags":["utxos","commitments","assets","contracts"],
+  "aliases":["single use seals","UTXO seals","outpoint seals"]
+}
+

--- a/content/nodes/extension.softchains.json
+++ b/content/nodes/extension.softchains.json
@@ -1,0 +1,36 @@
+{
+  "id": "extension.softchains",
+  "title": "Softchains",
+  "description": "Softchains are a proposed Bitcoin layer design in which an auxiliary chain is anchored to Bitcoin through a soft-fork-compatible mechanism. The design explores stronger Bitcoin enforcement while preserving separate execution environments.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.sidechains"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Layer Two Resources",
+      "url": "https://www.lopp.net/bitcoin-information/other-layers.html",
+      "notes": "Curated entry point to the softchain proposal and related layer designs."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Covenants",
+      "url": "https://bitcoinops.org/en/topics/covenants/",
+      "notes": "Background for Bitcoin-enforced spending constraints used by proposed layer designs."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin consensus, Script, and sidechain tradeoffs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": ["bitcoin-l2", "sidechains", "soft-forks", "covenants"],
+  "aliases": ["softchain", "softchains"]
+}
+

--- a/content/nodes/extension.spark.json
+++ b/content/nodes/extension.spark.json
@@ -1,0 +1,44 @@
+{
+  "id": "extension.spark",
+  "title": "Spark Protocol",
+  "description": "Spark is a Bitcoin Layer 2 protocol built on statechain ideas. It transfers off-chain representations of bitcoin without bilateral payment-channel management, using a distributed operator set and threshold-signature coordination while supporting Lightning interoperability and offline receiving.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.statechains"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Spark Protocol Documentation",
+      "url": "https://docs.spark.money/start/overview",
+      "notes": "Official overview of Spark's Bitcoin Layer 2 protocol and asset model."
+    },
+    {
+      "type": "article",
+      "title": "Spark Protocol Repository",
+      "url": "https://github.com/buildonspark/spark",
+      "notes": "Open-source implementation and protocol development reference."
+    },
+    {
+      "type": "book",
+      "title": "Mastering the Lightning Network",
+      "url": "https://amzn.to/40V421t",
+      "notes": "Background for Bitcoin Layer 2 payments, Lightning interoperability, and off-chain tradeoffs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4v6P9aq"
+      }
+    }
+  ],
+  "estimatedTime": "60m",
+  "tags": [
+    "bitcoin-l2",
+    "statechains",
+    "off-chain",
+    "lightning"
+  ],
+  "aliases": [
+    "Spark Bitcoin L2",
+    "Spark statechain protocol"
+  ]
+}
+

--- a/content/nodes/extension.spiderchains.json
+++ b/content/nodes/extension.spiderchains.json
@@ -1,0 +1,37 @@
+{
+  "id": "extension.spiderchains",
+  "title": "Spiderchains",
+  "description": "Spiderchains are a proposed Bitcoin sidechain architecture that uses a network of collateralized multisig operators and Bitcoin transactions to coordinate sidechain state and peg operations.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.sidechains",
+    "custody.multisig"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Spiderchain Whitepaper",
+      "url": "https://www.lopp.net/pdf/botanix-spiderchain-whitepaper.pdf",
+      "notes": "Primary design reference for the spiderchain architecture."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Layer Two Resources",
+      "url": "https://www.lopp.net/bitcoin-information/other-layers.html",
+      "notes": "Curated context for spiderchains among Bitcoin layer designs."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for sidechains, multisig, and Bitcoin transaction settlement.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "50m",
+  "tags": ["bitcoin-l2", "sidechains", "multisig", "peg"],
+  "aliases": ["spiderchain", "spiderchains"]
+}
+

--- a/content/nodes/extension.timeout-trees.json
+++ b/content/nodes/extension.timeout-trees.json
@@ -1,0 +1,43 @@
+{
+  "id": "extension.timeout-trees",
+  "title": "Timeout Trees",
+  "description": "Timeout Trees use a pre-signed transaction tree to virtualize many ownership outputs under a shared settlement structure, while preserving unilateral redemption after a timeout.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "protocol.timelocks"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Cube Bitcoin Repository",
+      "url": "https://github.com/cube-btc/cube",
+      "notes": "Implementation context for Cube's timeout-tree ownership and settlement design."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech: Timeout Trees",
+      "url": "https://bitcoinops.org/en/topics/timeout-trees/",
+      "notes": "Independent technical context for transaction-tree timeout constructions."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin transactions, Script, and timelocks.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "50m",
+  "tags": [
+    "bitcoin-l2",
+    "timelocks",
+    "off-chain",
+    "settlement"
+  ],
+  "aliases": [
+    "timeout trees",
+    "transaction timeout trees"
+  ]
+}

--- a/content/nodes/extension.zktlcs.json
+++ b/content/nodes/extension.zktlcs.json
@@ -1,0 +1,45 @@
+{
+  "id": "extension.zktlcs",
+  "title": "Zero-Knowledge Time-Locked Contracts",
+  "description": "Zero-Knowledge Time-Locked Contracts (ZKTLCs) combine timeout-tree ownership virtualization with BitVM-style disprovable computation, allowing a participant to challenge incorrect execution while retaining a unilateral timeout exit.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "extension.timeout-trees",
+    "extension.bitvm"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Cube Bitcoin Repository",
+      "url": "https://github.com/cube-btc/cube",
+      "notes": "Implementation context for Cube's Bitcoin-native programmable execution and challenge-response design."
+    },
+    {
+      "type": "article",
+      "title": "BitVM",
+      "url": "https://bitvm.org/",
+      "notes": "Primary reference for optimistic, challengeable computation anchored to Bitcoin."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin Script, transactions, and the settlement layer.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "75m",
+  "tags": [
+    "bitcoin-l2",
+    "bitvm",
+    "contracts",
+    "zk"
+  ],
+  "aliases": [
+    "ZKTLCs",
+    "ZK time-locked contracts",
+    "zero-knowledge time-locked contracts"
+  ]
+}

--- a/content/nodes/history.economic-majority.json
+++ b/content/nodes/history.economic-majority.json
@@ -1,0 +1,36 @@
+{
+  "id": "history.economic-majority",
+  "title": "Economic Majority",
+  "description": "The economic majority is the set of participants willing and able to accept Bitcoin in exchange for goods, services, or other currencies. This governance theory argues that miners cannot successfully impose a protocol change that the economically relevant users reject, because those users can refuse to recognize the resulting chain or assign it economic value.",
+  "category": "History & Governance",
+  "prerequisites": [
+    "protocol.nodes-vs-miners",
+    "economics.schelling-points"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Wiki: Economic Majority",
+      "url": "https://en.bitcoin.it/wiki/Economic_majority",
+      "notes": "Original formulation of the theory and its relationship to miner incentives, merchants, and protocol changes."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Wiki: Full Node",
+      "url": "https://en.bitcoin.it/wiki/Full_node",
+      "notes": "Related discussion of economic strength and why economic participants benefit from independently verifying the rules."
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": [
+    "governance",
+    "economics",
+    "consensus"
+  ],
+  "aliases": [
+    "economic majority",
+    "economic actors in bitcoin",
+    "merchant majority"
+  ]
+}
+

--- a/content/nodes/history.satoshi-nakamoto.json
+++ b/content/nodes/history.satoshi-nakamoto.json
@@ -1,0 +1,37 @@
+{
+  "id": "history.satoshi-nakamoto",
+  "title": "Satoshi Nakamoto",
+  "description": "Satoshi Nakamoto is the pseudonym used by the person or group that designed and launched Bitcoin. The disappearance of that identity is part of Bitcoin's separation from a permanent founder or controlling authority.",
+  "category": "History & Governance",
+  "prerequisites": [
+    "history.cypherpunk-roots-bitcoin-origin"
+  ],
+  "resources": [
+    {
+      "type": "book",
+      "title": "The Book of Satoshi",
+      "url": "https://amzn.to/4lvhhQ8",
+      "notes": "Primary-source collection of Satoshi's writings and early Bitcoin discussions.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/3NWFpyF"
+      }
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Whitepaper",
+      "url": "https://bitcoin.org/bitcoin.pdf",
+      "notes": "The founding design document published under the Satoshi Nakamoto pseudonym."
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": [
+    "history",
+    "origins",
+    "pseudonymity"
+  ],
+  "aliases": [
+    "Satoshi",
+    "Bitcoin creator"
+  ]
+}
+

--- a/content/nodes/lightning.dns-seeds.json
+++ b/content/nodes/lightning.dns-seeds.json
@@ -1,0 +1,54 @@
+{
+  "id": "lightning.dns-seeds",
+  "title": "Lightning DNS Seeds",
+  "description": "Lightning DNS seeds use DNS queries to bootstrap nodes with no known contacts and to locate the current address of a known peer, filtering results by Lightning realm, address type, node ID, and reply count.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "ops.dns-seeds",
+    "lightning.gossip-protocol"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BOLT 10: DNS Bootstrap and Assisted Node Location",
+      "url": "https://github.com/lightning/bolts/blob/master/10-dns-bootstrap.md",
+      "notes": "Canonical specification for Lightning DNS seed queries, realm and address filters, node-ID lookup, and DNS replies."
+    },
+    {
+      "type": "article",
+      "title": "BOLT 07: P2P Node and Channel Discovery",
+      "url": "https://github.com/lightning/bolts/blob/master/07-routing-gossip.md",
+      "notes": "Defines the Lightning node and channel discovery context that DNS bootstrap supplements."
+    },
+    {
+      "type": "article",
+      "title": "BOLT 01: Base Lightning Messaging",
+      "url": "https://github.com/lightning/bolts/blob/master/01-messaging.md",
+      "notes": "Defines the default Lightning port used by DNS seed responses."
+    },
+    {
+      "type": "book",
+      "title": "Mastering the Lightning Network",
+      "url": "https://amzn.to/40V421t",
+      "notes": "Background for Lightning peer connectivity, routing, and network discovery.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4v6P9aq"
+      }
+    }
+  ],
+  "estimatedTime": "40m",
+  "tags": [
+    "lightning",
+    "dns",
+    "peer-discovery",
+    "networking",
+    "gossip"
+  ],
+  "aliases": [
+    "Lightning DNS bootstrap",
+    "DNS bootstrap",
+    "assisted node location",
+    "BOLT 10"
+  ]
+}
+

--- a/content/nodes/lightning.encrypted-authenticated-transport.json
+++ b/content/nodes/lightning.encrypted-authenticated-transport.json
@@ -1,0 +1,46 @@
+{
+  "id": "lightning.encrypted-authenticated-transport",
+  "title": "Lightning Encrypted and Authenticated Transport",
+  "description": "How Lightning peers use the Noise_XK handshake and elliptic-curve Diffie–Hellman to authenticate node identities, derive session keys, and protect framed messages with authenticated encryption.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "fundamentals.public-private-keys",
+    "fundamentals.diffie-hellman-key-exchange"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BOLT 08: Encrypted and Authenticated Transport",
+      "url": "https://github.com/lightning/bolts/blob/master/08-transport.md",
+      "notes": "Canonical Lightning transport specification covering Noise_XK, key derivation, ChaCha20-Poly1305, and framed message protection."
+    },
+    {
+      "type": "article",
+      "title": "The Noise Protocol Framework",
+      "url": "https://noiseprotocol.org/noise.html",
+      "notes": "Reference for the handshake patterns and authenticated key exchange model used by BOLT 08."
+    },
+    {
+      "type": "book",
+      "title": "Mastering the Lightning Network",
+      "url": "https://amzn.to/40V421t",
+      "notes": "Broader context for Lightning peer connections and protocol security.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4v6P9aq"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "lightning",
+    "transport",
+    "encryption",
+    "authentication"
+  ],
+  "aliases": [
+    "BOLT 08 transport",
+    "Lightning Noise transport",
+    "Lightning encrypted transport"
+  ]
+}
+

--- a/content/nodes/lightning.feature-flags.json
+++ b/content/nodes/lightning.feature-flags.json
@@ -1,0 +1,44 @@
+{
+  "id": "lightning.feature-flags",
+  "title": "Lightning Feature Flags",
+  "description": "Capability bits that Lightning peers advertise in init messages, gossip announcements, invoices, and related protocol contexts. Odd and even bit pairs distinguish optional support from required support so implementations can negotiate features safely.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "lightning.gossip-protocol"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BOLT 09: Features",
+      "url": "https://github.com/lightning/bolts/blob/master/09-features.md",
+      "notes": "Canonical registry and semantics for optional and required Lightning feature bits."
+    },
+    {
+      "type": "article",
+      "title": "BOLT 01: Base Protocol",
+      "url": "https://github.com/lightning/bolts/blob/master/01-messaging.md",
+      "notes": "Defines how feature vectors are exchanged in init messages and attached to protocol messages."
+    },
+    {
+      "type": "book",
+      "title": "Mastering the Lightning Network",
+      "url": "https://amzn.to/40V421t",
+      "notes": "Provides implementation context for Lightning negotiation, announcements, and interoperable peer behavior.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4v6P9aq"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "lightning",
+    "protocol",
+    "interoperability"
+  ],
+  "aliases": [
+    "Lightning feature bits",
+    "Lightning capability negotiation",
+    "BOLT 09 features"
+  ]
+}
+

--- a/content/nodes/lightning.onion-messages.json
+++ b/content/nodes/lightning.onion-messages.json
@@ -1,0 +1,45 @@
+{
+  "id": "lightning.onion-messages",
+  "title": "Lightning Onion Messages",
+  "description": "Unreliable, channel-independent encrypted messages forwarded over blinded onion paths. Onion messages let Lightning peers transport requests and responses without requiring a payment HTLC or exposing the sender's destination topology.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "lightning.feature-flags",
+    "lightning.route-blinding"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BOLT 04: Onion Routing Protocol",
+      "url": "https://github.com/lightning/bolts/blob/master/04-onion-routing.md#onion-messages",
+      "notes": "Canonical specification for forwarding onion messages over blinded paths without a payment channel."
+    },
+    {
+      "type": "article",
+      "title": "BOLT 09: Features",
+      "url": "https://github.com/lightning/bolts/blob/master/09-features.md",
+      "notes": "Defines the option_onion_messages capability used to negotiate support."
+    },
+    {
+      "type": "book",
+      "title": "Mastering the Lightning Network",
+      "url": "https://amzn.to/40V421t",
+      "notes": "Provides broader context for Lightning onion routing, privacy, and channel-independent communication.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4v6P9aq"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "lightning",
+    "onion-routing",
+    "privacy"
+  ],
+  "aliases": [
+    "onion messages",
+    "channel-independent messages",
+    "BOLT 04 onion messages"
+  ]
+}
+

--- a/content/nodes/lightning.short-channel-id.json
+++ b/content/nodes/lightning.short-channel-id.json
@@ -1,0 +1,46 @@
+{
+  "id": "lightning.short-channel-id",
+  "title": "Short Channel IDs",
+  "description": "A Short Channel ID compactly identifies a Lightning channel's funding output by encoding its block height, transaction index, and output index. It lets gossip messages refer to the same on-chain channel without repeating the full transaction outpoint.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "lightning.payment-channels",
+    "protocol.block-height"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BOLT 07: Short Channel ID",
+      "url": "https://github.com/lightning/bolts/blob/master/07-routing-gossip.md#definition-of-short_channel_id",
+      "notes": "Canonical encoding and use of the identifier in Lightning gossip."
+    },
+    {
+      "type": "article",
+      "title": "BOLT 03: Funding Transaction Output",
+      "url": "https://github.com/lightning/bolts/blob/master/03-transactions.md#funding-transaction-output",
+      "notes": "Connects the identifier to the on-chain funding output that creates a channel."
+    },
+    {
+      "type": "book",
+      "title": "Mastering the Lightning Network",
+      "url": "https://amzn.to/40V421t",
+      "notes": "Technical background for channel identifiers, gossip, and Lightning routing.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4v6P9aq"
+      }
+    }
+  ],
+  "estimatedTime": "25m",
+  "tags": [
+    "lightning",
+    "channels",
+    "gossip",
+    "identifiers"
+  ],
+  "aliases": [
+    "short_channel_id",
+    "SCID",
+    "short channel identifier"
+  ]
+}
+

--- a/content/nodes/mining.block-withholding.json
+++ b/content/nodes/mining.block-withholding.json
@@ -1,0 +1,36 @@
+{
+  "id": "mining.block-withholding",
+  "title": "Block Withholding",
+  "description": "Block withholding is a pooled-mining attack in which a miner submits ordinary shares for payment but withholds a block-valid share, sacrificing little personal revenue while denying the pool the block reward.",
+  "category": "Mining",
+  "prerequisites": [
+    "mining.pool-shares"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Optech: Block Withholding",
+      "url": "https://bitcoinops.org/en/topics/block-withholding/",
+      "notes": "Defines the attack, its pool-economics asymmetry, common mitigations, and oblivious shares as a proposed remedy."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech: Pooled Mining",
+      "url": "https://bitcoinops.org/en/topics/pooled-mining/",
+      "notes": "Explains share targets and payout models required to understand why selective withholding harms the pool."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background on proof of work, mining incentives, and the pooled-mining environment in which the attack occurs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": ["mining", "pools", "attacks", "incentives", "shares"],
+  "aliases": ["block withholding attack", "withholding attack", "oblivious shares"]
+}
+

--- a/content/nodes/mining.merge-mining.json
+++ b/content/nodes/mining.merge-mining.json
@@ -1,0 +1,45 @@
+{
+  "id": "mining.merge-mining",
+  "title": "Merged Mining",
+  "description": "Merged mining lets miners use the same proof-of-work to secure more than one compatible blockchain. An auxiliary chain can accept work demonstrated by a parent-chain block, allowing miners to earn additional rewards without proportionally increasing hashing work.",
+  "category": "Mining",
+  "prerequisites": [
+    "protocol.proof-of-work"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Wiki: Merged Mining",
+      "url": "https://en.bitcoin.it/wiki/Merged_mining",
+      "notes": "Conceptual and protocol overview of auxiliary proof-of-work."
+    },
+    {
+      "type": "article",
+      "title": "Merge Mining Monitor",
+      "url": "https://mmm.deadmanoz.xyz/",
+      "notes": "Operational view of merged-mining activity and supported networks."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for proof-of-work, mining incentives, and block validation.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "mining",
+    "proof-of-work",
+    "sidechains",
+    "security"
+  ],
+  "aliases": [
+    "merged mining",
+    "auxiliary proof-of-work",
+    "auxpow"
+  ]
+}
+

--- a/content/nodes/mining.miner-decentralization.json
+++ b/content/nodes/mining.miner-decentralization.json
@@ -1,0 +1,43 @@
+{
+  "id": "mining.miner-decentralization",
+  "title": "Miner Decentralization",
+  "description": "Miner decentralization means transaction ordering is performed by a changing, open set of miners rather than one coordinator. It limits censorship power, while independently validating nodes still determine whether proposed blocks obey consensus rules.",
+  "category": "Mining",
+  "prerequisites": [
+    "protocol.nodes-vs-miners",
+    "mining.pool-vs-solo"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Development Philosophy: Miner Decentralization",
+      "url": "https://bitcoindevphilosophy.com/#minerdecentralization",
+      "notes": "Explains why a dynamic, permissionless mining set protects transaction ordering from centralized censorship."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Whitepaper",
+      "url": "https://bitcoin.org/bitcoin.pdf",
+      "notes": "Defines proof-of-work's distributed timestamping and longest-chain model."
+    },
+    {
+      "type": "article",
+      "title": "Stratum V2 Specification",
+      "url": "https://stratumprotocol.org/specification/",
+      "notes": "Implementation context for mining-pool protocols and job negotiation; not required to understand the broader concept."
+    },
+    {
+      "type": "book",
+      "title": "Bitcoin Development Philosophy",
+      "url": "https://amzn.to/4s33eUd",
+      "notes": "Long-form treatment of decentralization, censorship resistance, and the distinct roles of miners and full nodes.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4uRjb1v"
+      }
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": ["mining", "decentralization", "censorship-resistance", "governance"],
+  "aliases": ["mining decentralization", "hashrate decentralization", "decentralized transaction ordering"]
+}
+

--- a/content/nodes/mining.selfish-mining.json
+++ b/content/nodes/mining.selfish-mining.json
@@ -1,0 +1,32 @@
+{
+  "id": "mining.selfish-mining",
+  "title": "Selfish Mining",
+  "description": "Selfish mining is an incentive attack in which miners withhold privately found blocks and reveal them strategically to gain a chain-selection and propagation advantage over honest miners.",
+  "category": "Mining",
+  "prerequisites": ["mining.pool-vs-solo", "protocol.reorgs-finality"],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Dev Project: Selfish Mining explained simply",
+      "url": "https://x.com/Bitcoin_Devs/status/1975289920634925475",
+      "notes": "Learner-facing explanation of the withholding strategy and incentive attack."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Academy: P2P Attacks",
+      "url": "https://bitcoincore.academy/p2p-attacks.html",
+      "notes": "Attack-model context for mining and network behavior."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Reference background for proof of work, mining incentives, and chain selection.",
+      "regionalUrls": {"BR": "https://amzn.to/4te47JX"}
+    }
+  ],
+  "estimatedTime": "40m",
+  "tags": ["mining", "incentives", "attacks"],
+  "aliases": ["selfish mining attack", "block withholding for chain advantage"]
+}
+

--- a/content/nodes/ops.mempool-cluster-limits.json
+++ b/content/nodes/ops.mempool-cluster-limits.json
@@ -1,0 +1,54 @@
+{
+  "id": "ops.mempool-cluster-limits",
+  "title": "Mempool Cluster Limits",
+  "description": "Bitcoin Core limits each connected mempool cluster to a bounded transaction count and aggregate virtual size, replacing legacy ancestor and descendant limits so package admission, relay, replacement, and block-selection decisions remain computationally tractable.",
+  "category": "Network, Relay & Client Sync",
+  "prerequisites": [
+    "protocol.cluster-mempool"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Core 31.0 Release Notes: Cluster Limits",
+      "url": "https://bitcoincore.org/en/releases/31.0/",
+      "notes": "Defines the default 64-transaction and 101 kB virtual-size cluster limits and their replacement of ancestor/descendant limits."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core v31.0 Cluster Policy Configuration",
+      "url": "https://github.com/bitcoin/bitcoin/blob/v31.0/src/init.cpp",
+      "notes": "Implementation configuration context for cluster policy limits and their node-level overrides."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech Topic: Cluster Mempool",
+      "url": "https://bitcoinops.org/en/topics/cluster-mempool/",
+      "notes": "Explains why bounded clusters make chunk linearization and policy decisions computationally feasible."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for transaction packages, mempool policy, fees, and node operations.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "mempool",
+    "cluster-mempool",
+    "policy",
+    "packages",
+    "cpfp",
+    "rbf"
+  ],
+  "aliases": [
+    "cluster limits",
+    "mempool cluster size limits",
+    "cluster transaction limits",
+    "ancestor and descendant limit replacement"
+  ]
+}
+

--- a/content/nodes/ops.mempool-purging.json
+++ b/content/nodes/ops.mempool-purging.json
@@ -1,0 +1,50 @@
+{
+  "id": "ops.mempool-purging",
+  "title": "Mempool Purging and Rolling Minimum Fee",
+  "description": "How a node raises its rolling minimum relay feerate under mempool pressure and evicts transactions below that threshold as the mempool is trimmed. This is local policy and eviction behavior, not consensus or fee estimation.",
+  "category": "Network, Relay & Client Sync",
+  "prerequisites": [
+    "ops.mempool-policy"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Core Policy Documentation",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/policy/README.md",
+      "notes": "Canonical explanation of mempool policy, minimum relay feerates, and eviction behavior."
+    },
+    {
+      "type": "article",
+      "title": "getmempoolinfo RPC",
+      "url": "https://developer.bitcoin.org/reference/rpc/getmempoolinfo.html",
+      "notes": "Shows the current mempool size, memory usage, and rolling minimum fee rate exposed by Bitcoin Core."
+    },
+    {
+      "type": "article",
+      "title": "Mempool.space FAQ",
+      "url": "https://mempool.space/docs/faq",
+      "notes": "Operational view of mempool fullness, stuck transactions, and the purging fee rate shown by the explorer."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for mempool behavior, feerates, relay policy, and transaction confirmation tradeoffs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "mempool",
+    "fees",
+    "node-operations"
+  ],
+  "aliases": [
+    "mempool eviction",
+    "rolling minimum fee",
+    "mempool purging"
+  ]
+}
+

--- a/content/nodes/protocol.base58check.json
+++ b/content/nodes/protocol.base58check.json
@@ -1,0 +1,45 @@
+{
+  "id": "protocol.base58check",
+  "title": "Base58Check Encoding",
+  "description": "Bitcoin's Base58Check encoding represents versioned payloads such as legacy addresses and WIF keys with a human-friendly alphabet and checksum. The format includes network-specific version bytes, preserves leading zero bytes, and detects many transcription errors.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "fundamentals.hash-functions",
+    "protocol.addresses-outputs"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Wiki: Base58Check encoding",
+      "url": "https://en.bitcoin.it/wiki/Base58Check_encoding",
+      "notes": "Detailed explanation of the alphabet, version bytes, checksum, and leading-zero handling."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Developer Guide: Base58Check Encoding",
+      "url": "https://developer.bitcoin.org/devguide/wallets.html#base58check-encoding",
+      "notes": "Canonical developer reference for addresses and WIF serialization."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Hands-on treatment of Base58 encoding, checksums, addresses, and key serialization.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4lX5bzw"
+      }
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": [
+    "encoding",
+    "addresses",
+    "keys"
+  ],
+  "aliases": [
+    "base58check",
+    "base58 check encoding",
+    "base58 checksum"
+  ]
+}
+

--- a/content/nodes/protocol.byte-order.json
+++ b/content/nodes/protocol.byte-order.json
@@ -1,0 +1,46 @@
+{
+  "id": "protocol.byte-order",
+  "title": "Bitcoin Byte Order",
+  "description": "Bitcoin serializes many numeric fields in little-endian byte order while commonly displaying hashes and identifiers in reversed human-readable order. Keeping wire order separate from display order prevents parsing and transaction-construction errors.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.transaction-lifecycle"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Learn Me a Bitcoin: Byte Order",
+      "url": "https://learnmeabitcoin.com/technical/general/byte-order/",
+      "notes": "Practical explanation of little-endian serialization and reversed hash display."
+    },
+    {
+      "type": "article",
+      "title": "Learn Me a Bitcoin: Little Endian",
+      "url": "https://learnmeabitcoin.com/technical/general/little-endian/",
+      "notes": "Concrete examples of converting numbers and byte sequences in Bitcoin data."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Hands-on context for serializing integers, hashes, transactions, and block data.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4lX5bzw"
+      }
+    }
+  ],
+  "estimatedTime": "25m",
+  "tags": [
+    "serialization",
+    "endianness",
+    "transactions",
+    "parsing"
+  ],
+  "aliases": [
+    "byte order",
+    "little endian",
+    "little-endian encoding",
+    "hash byte order"
+  ]
+}
+

--- a/content/nodes/protocol.coinbase-maturity.json
+++ b/content/nodes/protocol.coinbase-maturity.json
@@ -1,0 +1,45 @@
+{
+  "id": "protocol.coinbase-maturity",
+  "title": "Coinbase Maturity",
+  "description": "Newly mined coinbase outputs cannot be spent until 100 blocks have been added after the containing block. This consensus rule protects the spendability of mining rewards while short-lived reorganizations are still possible.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.coinbase-transaction",
+    "fundamentals.settlement-assurances"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Wiki: Confirmation",
+      "url": "https://en.bitcoin.it/wiki/Confirmation#Number_of_Confirmations",
+      "notes": "Documents the 100-confirmation maturity rule for coinbase transactions."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core: Consensus Code",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/src/validation.cpp",
+      "notes": "Implementation reference for coinbase-spend validation and maturity enforcement."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Explains coinbase transactions, block rewards, confirmations, and reorganization risk.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "20m",
+  "tags": [
+    "consensus",
+    "mining",
+    "coinbase"
+  ],
+  "aliases": [
+    "coinbase maturity",
+    "100 block coinbase maturity",
+    "maturity period for mined coins"
+  ]
+}
+

--- a/content/nodes/protocol.commit-delay-reveal.json
+++ b/content/nodes/protocol.commit-delay-reveal.json
@@ -1,0 +1,32 @@
+{
+  "id": "protocol.commit-delay-reveal",
+  "title": "Commit-Delay-Reveal Protocol",
+  "description": "A commit-delay-reveal protocol commits to a value, waits through a delay, and reveals it later so participants cannot adapt their choice after seeing other commitments. The pattern composes cryptographic commitments with timing and coordination rules.",
+  "category": "Protocol & Consensus",
+  "prerequisites": ["fundamentals.commitment-schemes"],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Dev Project: Commit-Delay-Reveal Protocol explained",
+      "url": "https://x.com/Bitcoin_Devs/status/1931775486449103086",
+      "notes": "Learner-facing explanation of the CDR protocol pattern."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech Topics",
+      "url": "https://bitcoinops.org/en/topics/",
+      "notes": "Canonical source index for Bitcoin protocol proposals that use commitment and reveal patterns."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Reference background for commitments, scripts, and Bitcoin protocol coordination.",
+      "regionalUrls": {"BR": "https://amzn.to/4te47JX"}
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": ["commitments", "protocols", "coordination"],
+  "aliases": ["CDR protocol", "commit delay reveal"]
+}
+

--- a/content/nodes/protocol.compact-size-encoding.json
+++ b/content/nodes/protocol.compact-size-encoding.json
@@ -1,0 +1,45 @@
+{
+  "id": "protocol.compact-size-encoding",
+  "title": "CompactSize Encoding",
+  "description": "CompactSize is Bitcoin's variable-length integer encoding for counts and byte lengths in serialized protocol data. Understanding its prefixes is necessary for parsing transaction, block, script, and network messages correctly.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.transaction-lifecycle"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Learn Me a Bitcoin: Compact Size",
+      "url": "https://learnmeabitcoin.com/technical/general/compact-size/",
+      "notes": "Visual explanation of Bitcoin's variable-length integer format and decoding rules."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Developer Documentation: Serialization",
+      "url": "https://developer.bitcoin.org/reference/transactions.html",
+      "notes": "Reference context for CompactSize fields in transaction serialization."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Hands-on treatment of parsing and serializing Bitcoin transaction data.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4lX5bzw"
+      }
+    }
+  ],
+  "estimatedTime": "25m",
+  "tags": [
+    "serialization",
+    "transactions",
+    "protocol",
+    "parsing"
+  ],
+  "aliases": [
+    "compact size",
+    "compact-size integer",
+    "var_int"
+  ]
+}
+

--- a/content/nodes/protocol.confidential-transactions.json
+++ b/content/nodes/protocol.confidential-transactions.json
@@ -1,0 +1,46 @@
+{
+  "id": "protocol.confidential-transactions",
+  "title": "Confidential Transactions",
+  "description": "Confidential Transactions hide transaction amounts and selected asset information while preserving verifiability through cryptographic commitments and range proofs. Elements and Liquid use this model as a core privacy and asset-transfer feature.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "fundamentals.commitment-schemes"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Liquid Technical Overview",
+      "url": "https://docs.liquid.net/docs/technical-overview",
+      "notes": "Official overview of Liquid's confidential transactions and issued-asset model."
+    },
+    {
+      "type": "article",
+      "title": "Elements Repository",
+      "url": "https://github.com/ElementsProject/elements",
+      "notes": "Open-source platform implementation and technical documentation."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for cryptographic commitments, transaction validation, and Bitcoin's UTXO model.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "60m",
+  "tags": [
+    "privacy",
+    "commitments",
+    "range-proofs",
+    "liquid",
+    "elements"
+  ],
+  "aliases": [
+    "Confidential Transactions",
+    "confidential assets",
+    "CT"
+  ]
+}
+

--- a/content/nodes/protocol.generalized-covenants.json
+++ b/content/nodes/protocol.generalized-covenants.json
@@ -1,0 +1,36 @@
+{
+  "id": "protocol.generalized-covenants",
+  "title": "Generalized Covenants",
+  "description": "Generalized covenants are covenant designs that can express broad constraints over future transaction structure rather than one narrowly defined spending pattern. They provide a useful boundary for comparing flexible introspection mechanisms with restricted covenant proposals such as CTV or vault-specific constructions.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.covenants"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Covenants Research Compilation",
+      "url": "https://bitcoincovenants.com/",
+      "notes": "Defines generalized versus restricted covenants and surveys the main construction families."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech: Covenants",
+      "url": "https://bitcoinops.org/en/topics/covenants/",
+      "notes": "Current technical context for covenant proposals and tradeoffs."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Background for Script, signatures, and transaction construction.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4lX5bzw"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": ["covenants", "script", "transaction-introspection", "protocol-design"],
+  "aliases": ["generalized covenant", "general covenants"]
+}
+

--- a/content/nodes/protocol.generic-signed-messages.json
+++ b/content/nodes/protocol.generic-signed-messages.json
@@ -1,0 +1,46 @@
+{
+  "id": "protocol.generic-signed-messages",
+  "title": "Generic Signed Message Format",
+  "description": "BIP 322 uses virtual transactions to prove that a signer can satisfy a Bitcoin scriptPubKey for a message without spending or broadcasting funds.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.script"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 322: Generic Signed Message Format",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki",
+      "notes": "Canonical specification for signing and verifying messages against arbitrary Bitcoin output scripts using virtual transactions."
+    },
+    {
+      "type": "article",
+      "title": "BIP 174: Partially Signed Bitcoin Transaction Format",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki",
+      "notes": "Related transaction-serialization context for the virtual transaction model and script-aware signing workflows."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Hands-on context for Script, signatures, transactions, and constructing verifiable Bitcoin spending conditions.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4lX5bzw"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "signatures",
+    "messages",
+    "script",
+    "interoperability"
+  ],
+  "aliases": [
+    "BIP 322",
+    "BIP322",
+    "generic signed messages",
+    "Bitcoin signed message format"
+  ]
+}
+

--- a/content/nodes/protocol.mast.json
+++ b/content/nodes/protocol.mast.json
@@ -1,0 +1,32 @@
+{
+  "id": "protocol.mast",
+  "title": "Merkelized Alternative Script Trees (MAST)",
+  "description": "MAST commits to multiple Bitcoin Script spending branches in a Merkle tree while revealing only the branch used to spend. It reduces revealed policy and witness data without hiding the committed alternatives from verification.",
+  "category": "Protocol & Consensus",
+  "prerequisites": ["fundamentals.merkle-trees", "protocol.script"],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Dev Project: MAST explained simply",
+      "url": "https://x.com/Bitcoin_Devs/status/1998431297333501989",
+      "notes": "Short learner-facing explanation of Merkleized Alternative Script Trees."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech Topic: MAST",
+      "url": "https://bitcoinops.org/en/topics/mast/",
+      "notes": "Technical context for script-tree commitments and selective branch revelation."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Worked background on Bitcoin scripts, hashing, and Merkle commitments.",
+      "regionalUrls": {"BR": "https://amzn.to/4lX5bzw"}
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": ["scripts", "merkle", "privacy", "contracts"],
+  "aliases": ["MAST", "merkelized alternative script tree", "Merkelized Alternative Script Tree"]
+}
+

--- a/content/nodes/protocol.op-checkcontractverify.json
+++ b/content/nodes/protocol.op-checkcontractverify.json
@@ -1,0 +1,36 @@
+{
+  "id": "protocol.op-checkcontractverify",
+  "title": "OP_CHECKCONTRACTVERIFY (BIP 443)",
+  "description": "OP_CHECKCONTRACTVERIFY is a proposed covenant opcode for constructing state-carrying outputs and vault-like spending policies. It generalizes the covenant capabilities needed by OP_VAULT while supporting broader contract patterns.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.covenants"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Covenant Proposals Compared",
+      "url": "https://www.spark.money/tools/bitcoin-covenant-proposals-compared",
+      "notes": "Current comparison of BIP 443 with OP_VAULT and other covenant proposals."
+    },
+    {
+      "type": "article",
+      "title": "BIP 443: OP_CHECKCONTRACTVERIFY",
+      "url": "https://bips.dev/443/",
+      "notes": "Proposal specification and motivation for a more general contract-verification opcode."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Background for Script, transaction construction, and covenant mechanisms.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4lX5bzw"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": ["covenants", "vaults", "script", "protocol-proposals"],
+  "aliases": ["OP_CHECKCONTRACTVERIFY", "BIP 443", "OP_CCV"]
+}
+

--- a/content/nodes/protocol.p2wpkh.json
+++ b/content/nodes/protocol.p2wpkh.json
@@ -1,0 +1,46 @@
+{
+  "id": "protocol.p2wpkh",
+  "title": "Pay-to-Witness-Public-Key-Hash (P2WPKH)",
+  "description": "SegWit version-0 output that commits to a 20-byte public-key hash and places the spending signature and public key in the witness. P2WPKH reduces transaction weight and avoids the legacy txid malleability problem while preserving the familiar single-key payment model.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.segregated-witness",
+    "protocol.p2pkh"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 141: Pay-to-Witness-Public-Key-Hash",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#pay-to-witness-public-key-hash",
+      "notes": "Canonical definition of the v0 witness program and its spending rules."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Wiki: Address",
+      "url": "https://en.bitcoin.it/wiki/Address#Pay_to_Witness_Public_Key_Hash",
+      "notes": "Address-level explanation of native SegWit P2WPKH outputs."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Explains native SegWit addresses, witness programs, and P2WPKH transaction structure.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": [
+    "segwit",
+    "addresses",
+    "scripts"
+  ],
+  "aliases": [
+    "p2wpkh",
+    "pay to witness public key hash",
+    "native segwit single-key output",
+    "segwit v0 key-hash output"
+  ]
+}
+

--- a/content/nodes/protocol.p2wsh.json
+++ b/content/nodes/protocol.p2wsh.json
@@ -1,0 +1,46 @@
+{
+  "id": "protocol.p2wsh",
+  "title": "Pay-to-Witness-Script-Hash (P2WSH)",
+  "description": "SegWit version-0 output that commits to the SHA256 hash of a witness script and reveals that script plus its witness stack when spent. P2WSH supports complex policies such as multisig with lower weight and no legacy scriptSig malleability.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.segregated-witness",
+    "protocol.pay-to-script-hash"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 141: Pay-to-Witness-Script-Hash",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#pay-to-witness-script-hash",
+      "notes": "Canonical definition of the v0 witness script hash program and witness validation."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Wiki: Address",
+      "url": "https://en.bitcoin.it/wiki/Address#Pay_to_Witness_Script_Hash",
+      "notes": "Address-level explanation of native SegWit P2WSH outputs."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Explains witness scripts, native SegWit multisig, and P2WSH spending structure.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "segwit",
+    "scripts",
+    "multisig"
+  ],
+  "aliases": [
+    "p2wsh",
+    "pay to witness script hash",
+    "native segwit script-hash output",
+    "segwit v0 script-hash output"
+  ]
+}
+

--- a/content/nodes/protocol.package-rbf.json
+++ b/content/nodes/protocol.package-rbf.json
@@ -1,0 +1,53 @@
+{
+  "id": "protocol.package-rbf",
+  "title": "Package RBF",
+  "description": "Current Bitcoin Core package RBF supports limited 1P1C-style replacement of conflicting in-mempool transaction packages when the replacement satisfies aggregate-fee, incremental-fee, cluster-limit, and feerate-improvement rules, allowing child fees to replace a package rather than only a single transaction.",
+  "category": "Network, Relay & Client Sync",
+  "prerequisites": [
+    "protocol.rbf"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Core Package Mempool Acceptance Policy",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/policy/packages.md",
+      "notes": "Canonical package topology, package-fee, and package-replacement policy context."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Mempool Replacements",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/policy/mempool-replacements.md",
+      "notes": "Current replacement conditions for absolute fees, incremental relay fees, conflicting clusters, and feerate-diagram improvement."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core 28 Wallet Integration Guide",
+      "url": "https://bitcoinops.org/en/bitcoin-core-28-wallet-integration-guide/",
+      "notes": "Practical 1P1C package-RBF examples showing how a child can carry fees for a replacement package."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for RBF, mempool policy, transaction packages, and fee-bumping tradeoffs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "55m",
+  "tags": [
+    "rbf",
+    "mempool",
+    "packages",
+    "fee-bumping",
+    "cluster-mempool"
+  ],
+  "aliases": [
+    "package RBF",
+    "package replace-by-fee",
+    "1P1C package RBF",
+    "package replacement"
+  ]
+}
+

--- a/content/nodes/protocol.partial-merkle-proofs.json
+++ b/content/nodes/protocol.partial-merkle-proofs.json
@@ -1,0 +1,44 @@
+{
+  "id": "protocol.partial-merkle-proofs",
+  "title": "Partial Merkle Proofs",
+  "description": "A compact proof that a transaction belongs to a block by sending only the relevant Merkle branches and a bit field describing the traversed tree, allowing an SPV client to verify inclusion without downloading every transaction.",
+  "category": "Network, Relay & Client Sync",
+  "prerequisites": [
+    "protocol.block-structure"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 37: Connection Bloom Filtering",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki",
+      "notes": "Defines merkleblock messages and partial Merkle tree proofs used by legacy SPV clients."
+    },
+    {
+      "type": "article",
+      "title": "Mastering Bitcoin: The Blockchain",
+      "url": "https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch11_blockchain.adoc",
+      "notes": "Explains how a lightweight client verifies transaction inclusion with a partial Merkle branch."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Provides the broader block, Merkle-tree, and lightweight-client context for partial proofs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "spv",
+    "light-clients",
+    "merkle-proofs"
+  ],
+  "aliases": [
+    "partial merkle trees",
+    "SPV proofs",
+    "merkleblock proofs"
+  ]
+}
+

--- a/content/nodes/protocol.pay-to-anchor.json
+++ b/content/nodes/protocol.pay-to-anchor.json
@@ -1,0 +1,44 @@
+{
+  "id": "protocol.pay-to-anchor",
+  "title": "Pay to Anchor",
+  "description": "Pay to Anchor is a keyless witness output pattern that leaves a compact fee-bumping hook in a transaction so a later child can improve confirmation without requiring privileged key material.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.ephemeral-anchors"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 433: Pay to Anchor",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0433.mediawiki",
+      "notes": "Draft specification for the keyless P2A output and its standard relay behavior."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech: Pay to Anchor",
+      "url": "https://bitcoinops.org/en/topics/ephemeral-anchors/",
+      "notes": "Optech groups P2A with ephemeral anchors and documents the fee-bumping context."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background on Bitcoin outputs, transaction fees, and child-pays-for-parent fee bumping.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "outputs",
+    "fee bumping",
+    "mempool",
+    "relay"
+  ],
+  "aliases": [
+    "P2A",
+    "pay-to-anchor output"
+  ]
+}
+

--- a/content/nodes/protocol.pay-to-contract.json
+++ b/content/nodes/protocol.pay-to-contract.json
@@ -1,0 +1,16 @@
+{
+  "id": "protocol.pay-to-contract",
+  "title": "Pay to Contract (P2C)",
+  "description": "Pay to Contract commits to offchain contract data by tweaking a public key with a hash-derived value, producing a payment destination that proves the commitment without placing the contract data onchain.",
+  "category": "Protocol & Consensus",
+  "prerequisites": ["fundamentals.public-private-keys", "fundamentals.hash-functions"],
+  "resources": [
+    {"type":"article","title":"Mastering Bitcoin: Applications","url":"https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch14_applications.adoc","notes":"Explains how key tweaking publicly commits to an external contract without revealing it onchain."},
+    {"type":"article","title":"Mastering Bitcoin: Authorization and Authentication","url":"https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch07_authorization-authentication.adoc","notes":"Provides the public-key and signature context for key-based commitments."},
+    {"type":"book","title":"Mastering Bitcoin","url":"https://amzn.to/4ro0NdG","notes":"Long-form treatment of Bitcoin keys, commitments, and application constructions.","regionalUrls":{"BR":"https://amzn.to/4te47JX"}}
+  ],
+  "estimatedTime":"35m",
+  "tags":["contracts","keys","commitments","privacy","applications"],
+  "aliases":["P2C","pay-to-contract protocol","key tweak commitment"]
+}
+

--- a/content/nodes/protocol.proof-of-payment.json
+++ b/content/nodes/protocol.proof-of-payment.json
@@ -1,0 +1,44 @@
+{
+  "id": "protocol.proof-of-payment",
+  "title": "Proof of Payment",
+  "description": "Proof of Payment is a wallet-generated transaction-shaped proof that demonstrates control of the credentials needed to spend the inputs of a prior payment, without exposing a password or personal identity.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.transaction-lifecycle"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 120: Proof of Payment",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0120.mediawiki",
+      "notes": "Specification for generating and validating a one-time proof tied to a previous payment."
+    },
+    {
+      "type": "article",
+      "title": "BIP 121: Proof of Payment URI Scheme",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0121.mediawiki",
+      "notes": "Historical companion for transporting proof-of-payment requests."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background on transaction authorization, signatures, and wallet-controlled credentials.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "payments",
+    "wallets",
+    "signatures",
+    "authentication"
+  ],
+  "aliases": [
+    "PoP",
+    "proof of payment protocol"
+  ]
+}
+

--- a/content/nodes/protocol.recursive-covenants.json
+++ b/content/nodes/protocol.recursive-covenants.json
@@ -1,0 +1,36 @@
+{
+  "id": "protocol.recursive-covenants",
+  "title": "Recursive Covenants",
+  "description": "Recursive covenants are spending constraints that reproduce or preserve covenant conditions in the outputs created by a spend. They can enforce rules across repeated transaction generations and therefore introduce distinct liveness, escape, and complexity tradeoffs.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.covenants"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Covenants Research Compilation",
+      "url": "https://bitcoincovenants.com/",
+      "notes": "Defines recursive covenants and places them in the broader covenant design space."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech: Covenants",
+      "url": "https://bitcoinops.org/en/topics/covenants/",
+      "notes": "Technical context for covenant recursion, exits, and application tradeoffs."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Background for Script, transaction outputs, and spending conditions.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4lX5bzw"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": ["covenants", "recursive", "script", "transaction-introspection"],
+  "aliases": ["recursive covenant", "covenant recursion"]
+}
+

--- a/content/nodes/protocol.replacement-cycling.json
+++ b/content/nodes/protocol.replacement-cycling.json
@@ -1,0 +1,16 @@
+{
+  "id":"protocol.replacement-cycling",
+  "title":"Replacement Cycling",
+  "description":"Replacement cycling repeatedly uses RBF and CPFP to evict a time-sensitive multiparty transaction from the mempool, preventing its confirmation while the attacker can afford to keep cycling replacements.",
+  "category":"Network, Relay & Client Sync",
+  "prerequisites":["protocol.rbf","protocol.cpfp"],
+  "resources":[
+    {"type":"article","title":"Bitcoin Optech: Replacement Cycling","url":"https://bitcoinops.org/en/topics/replacement-cycling/","notes":"Explains the repeated RBF-and-CPFP eviction attack and its impact on contract protocols."},
+    {"type":"article","title":"Bitcoin Optech: Transaction Pinning","url":"https://bitcoinops.org/en/topics/transaction-pinning/","notes":"Context for the wider family of fee-bumping and confirmation-blocking attacks."},
+    {"type":"book","title":"Mastering Bitcoin","url":"https://amzn.to/4ro0NdG","notes":"Background on fee bumping, transaction packages, and mempool policy.","regionalUrls":{"BR":"https://amzn.to/4te47JX"}}
+  ],
+  "estimatedTime":"40m",
+  "tags":["mempool","rbf","cpfp","pinning","lightning","contracts"],
+  "aliases":["replacement cycling attack","RBF cycling","transaction replacement cycling"]
+}
+

--- a/content/nodes/protocol.sighash-quadratic-hashing.json
+++ b/content/nodes/protocol.sighash-quadratic-hashing.json
@@ -1,0 +1,32 @@
+{
+  "id": "protocol.sighash-quadratic-hashing",
+  "title": "Quadratic SIGHASH Hashing Cost",
+  "description": "Legacy signature hashing repeated transaction-wide work for each input, creating quadratic validation cost as transactions grew. Cached digest designs such as BIP 143 address this performance failure while preserving signature-commitment semantics.",
+  "category": "Protocol & Consensus",
+  "prerequisites": ["protocol.sighash-flags"],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Dev Project: Quadratic Sighash problem explained",
+      "url": "https://x.com/Bitcoin_Devs/status/1987562939109306699",
+      "notes": "Learner-facing explanation of the historical O(n^2) hashing problem."
+    },
+    {
+      "type": "article",
+      "title": "BIP 143: Transaction Signature Verification",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki",
+      "notes": "Defines the digest structure and cached components that avoid repeated hashing work."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Background on transaction digests and signature verification.",
+      "regionalUrls": {"BR": "https://amzn.to/4lX5bzw"}
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": ["sighash", "performance", "consensus"],
+  "aliases": ["quadratic hashing problem", "quadratic SIGHASH", "O(n^2) SIGHASH"]
+}
+

--- a/content/nodes/protocol.strict-der-signatures.json
+++ b/content/nodes/protocol.strict-der-signatures.json
@@ -1,0 +1,50 @@
+{
+  "id": "protocol.strict-der-signatures",
+  "title": "Strict DER Signature Encoding",
+  "description": "The consensus rule that requires legacy ECDSA signatures in Bitcoin script to use strict Distinguished Encoding Rules (DER), rejecting ambiguous encodings that could otherwise create multiple valid transaction representations.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.script"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 66: Strict DER Signatures",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki",
+      "notes": "Canonical specification for the deployed strict-DER consensus rule and its validation behavior."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core BIP Implementation Index",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/bips.md",
+      "notes": "Shows how BIP 66 is implemented and deployed in Bitcoin Core."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Script Interpreter",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/src/script/interpreter.cpp",
+      "notes": "Implementation reference for signature-encoding checks during script evaluation."
+    },
+    {
+      "type": "book",
+      "title": "Programming Bitcoin",
+      "url": "https://amzn.to/4b5xUhC",
+      "notes": "Provides the signature, script, and transaction context needed to understand strict encoding rules.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4lX5bzw"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "consensus",
+    "signatures",
+    "malleability"
+  ],
+  "aliases": [
+    "strict DER",
+    "BIP 66",
+    "DER-encoded signatures"
+  ]
+}
+

--- a/content/nodes/protocol.taproot-control-blocks.json
+++ b/content/nodes/protocol.taproot-control-blocks.json
@@ -1,0 +1,16 @@
+{
+  "id": "protocol.taproot-control-blocks",
+  "title": "Taproot Control Blocks",
+  "description": "A Taproot control block is script-path witness data containing the internal key, output-key parity, and Merkle proof needed to verify that a revealed tapscript leaf was committed to the spent output.",
+  "category": "Protocol & Consensus",
+  "prerequisites": ["protocol.tapleaf-inclusion-proofs"],
+  "resources": [
+    {"type":"article","title":"BIP 341: Taproot","url":"https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki","notes":"Canonical control-block encoding and script-path validation rules."},
+    {"type":"article","title":"Bitcoin Optech Schnorr/Taproot Workshop","url":"https://bitcoinops.org/en/schnorr-taproot-workshop/","notes":"Workshop context for the script-path witness and Taproot tree verification."},
+    {"type":"book","title":"Mastering Bitcoin","url":"https://amzn.to/4ro0NdG","notes":"Background for Taproot outputs and witness construction.","regionalUrls":{"BR":"https://amzn.to/4te47JX"}}
+  ],
+  "estimatedTime":"30m",
+  "tags":["taproot","witness","scripts","merkle-proofs"],
+  "aliases":["control block","taproot script-path control block"]
+}
+

--- a/content/nodes/protocol.witness-structure.json
+++ b/content/nodes/protocol.witness-structure.json
@@ -1,0 +1,44 @@
+{
+  "id": "protocol.witness-structure",
+  "title": "Transaction Witness Structure",
+  "description": "The transaction-level witness serialization layout that stores one witness stack per input, including the marker, flag, item counts, and witness items that carry SegWit spending data outside the legacy input script.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.segregated-witness"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 141: Segregated Witness",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki",
+      "notes": "Canonical specification for the marker, flag, witness vectors, and transaction serialization rules."
+    },
+    {
+      "type": "article",
+      "title": "Mastering Bitcoin: Transactions",
+      "url": "https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch06_transactions.adoc",
+      "notes": "Explains witness serialization, one witness stack per input, compactSize counts, and empty stacks for legacy inputs."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Provides the broader transaction-serialization context needed to understand witness-aware inputs and outputs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "transactions",
+    "segwit",
+    "serialization"
+  ],
+  "aliases": [
+    "witness structure",
+    "segwit transaction structure",
+    "witness serialization"
+  ]
+}
+

--- a/content/nodes/security.bitcoin-core-rpc-access.json
+++ b/content/nodes/security.bitcoin-core-rpc-access.json
@@ -1,0 +1,52 @@
+{
+  "id": "security.bitcoin-core-rpc-access",
+  "title": "Bitcoin Core RPC Access Security",
+  "description": "Secure Bitcoin Core's powerful RPC control boundary by authenticating clients, limiting bind and allow rules, and understanding that RPC access can read private data, spend wallet funds, and change node behavior.",
+  "category": "Security",
+  "prerequisites": [
+    "dev.bitcoin-core-rpc"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Core JSON-RPC Interface: Security",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/JSON-RPC-interface.md#security",
+      "notes": "Canonical security guidance for RPC credentials, local versus remote exposure, and the authority granted by the interface."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Configuration Reference",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/doc/bitcoin-conf.md",
+      "notes": "Configuration reference for rpcbind, rpcallowip, cookie authentication, rpcauth, and related access controls."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core Initialization and Configuration",
+      "url": "https://github.com/bitcoin/bitcoin/blob/master/src/init.cpp",
+      "notes": "Implementation context for how Bitcoin Core parses and applies RPC access configuration."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for node operation, wallet authority, RPC workflows, and self-custody security tradeoffs.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "security",
+    "rpc",
+    "access-control",
+    "node-operations"
+  ],
+  "aliases": [
+    "Bitcoin Core RPC security",
+    "secure RPC exposure",
+    "RPC authentication",
+    "rpcauth"
+  ]
+}
+

--- a/content/nodes/security.dust-attack.json
+++ b/content/nodes/security.dust-attack.json
@@ -1,0 +1,32 @@
+{
+  "id": "security.dust-attack",
+  "title": "Dust Attack",
+  "description": "A dust attack sends trace-value outputs to targets so later spending can link their wallets or contaminate coin-control decisions. It exploits the gap between a policy threshold for tiny outputs and the privacy meaning of spending them.",
+  "category": "Security",
+  "prerequisites": ["protocol.dust-policy", "privacy.pseudonymity"],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Dev Project: Dust Attack explained",
+      "url": "https://x.com/Bitcoin_Devs/status/1904946739603452376",
+      "notes": "Learner-facing explanation of dusting as a privacy attack."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Developer Guide: Transactions",
+      "url": "https://developer.bitcoin.org/devguide/transactions.html",
+      "notes": "Canonical context for dust thresholds and transaction output policy."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Reference background for UTXOs, transaction construction, and privacy tradeoffs.",
+      "regionalUrls": {"BR": "https://amzn.to/4te47JX"}
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": ["privacy", "utxos", "attacks"],
+  "aliases": ["dusting attack", "dust attack"]
+}
+

--- a/content/nodes/security.quantum-computing-threat.json
+++ b/content/nodes/security.quantum-computing-threat.json
@@ -1,0 +1,38 @@
+{
+  "id": "security.quantum-computing-threat",
+  "title": "Quantum Computing Threats",
+  "description": "Large fault-tolerant quantum computers could weaken Bitcoin's public-key signature assumptions and accelerate proof-of-work search. The threat is distinct from ordinary key guessing and motivates migration planning for quantum-resistant authorization.",
+  "category": "Security",
+  "prerequisites": [
+    "fundamentals.digital-signatures"
+  ],
+  "resources": [
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Background for Bitcoin keys, signatures, and the security assumptions affected by future cryptanalytic advances.",
+      "regionalUrls": {
+        "BR": "https://amzn.to/4te47JX"
+      }
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech: Quantum Computing",
+      "url": "https://bitcoinops.org/en/topics/quantum-resistance/",
+      "notes": "Bitcoin-specific analysis of quantum attacks and migration considerations."
+    }
+  ],
+  "estimatedTime": "45m",
+  "tags": [
+    "security",
+    "cryptography",
+    "post-quantum"
+  ],
+  "aliases": [
+    "quantum threat",
+    "quantum attacks on Bitcoin",
+    "quantum resistance"
+  ]
+}
+

--- a/content/nodes/security.rogue-key-attack.json
+++ b/content/nodes/security.rogue-key-attack.json
@@ -1,0 +1,32 @@
+{
+  "id": "security.rogue-key-attack",
+  "title": "Rogue-Key Attack",
+  "description": "A rogue-key attack exploits naive public-key aggregation by choosing a related key that cancels another participant's key, making an aggregate signature appear authorized without the intended cooperation. Key aggregation protocols need binding or proof-of-possession defenses.",
+  "category": "Security",
+  "prerequisites": ["protocol.musig"],
+  "resources": [
+    {
+      "type": "article",
+      "title": "Bitcoin Dev Project: Schnorr rogue-key attack explained",
+      "url": "https://x.com/Bitcoin_Devs/status/1976008010108678258",
+      "notes": "Learner-facing explanation of the key-aggregation attack."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech Topic: MuSig",
+      "url": "https://bitcoinops.org/en/topics/musig/",
+      "notes": "Technical context for key aggregation and rogue-key defenses in multisignature constructions."
+    },
+    {
+      "type": "book",
+      "title": "Mastering Bitcoin",
+      "url": "https://amzn.to/4ro0NdG",
+      "notes": "Reference background for Schnorr signatures and multisignature coordination.",
+      "regionalUrls": {"BR": "https://amzn.to/4te47JX"}
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": ["schnorr", "multisig", "security"],
+  "aliases": ["rogue key attack", "key aggregation rogue-key attack"]
+}
+


### PR DESCRIPTION
## Summary
- add 67 new learner-facing nodes from the source-audit work
- cover custody, development, economics, extensions, history, Lightning, mining, operations, protocol, and security
- keep this PR limited to new node JSON files; existing-node curation and tooling changes remain outside this PR

## Validation
- `npm run build`
- `npm test` (108 tests)
- `npm run check:links`
