### PR TITLE
feat(content): add concepts from Delving Bitcoin audit

### DIFF
--- a/content/nodes/custody.psbt-signer-validation.json
+++ b/content/nodes/custody.psbt-signer-validation.json
@@ -1,0 +1,34 @@
+{
+  "id": "custody.psbt-signer-validation",
+  "title": "PSBT Signer Validation",
+  "description": "A PSBT signer should independently verify the referenced UTXOs, scripts, sighash type, amounts, fees, destinations, and change before producing signatures. The PSBT is a coordination container, not proof that the proposed transaction matches the signer's wallet policy or intent.",
+  "category": "Wallets",
+  "prerequisites": [
+    "custody.psbt"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 174: Partially Signed Bitcoin Transaction Format",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki",
+      "notes": "Canonical PSBT specification, including the checks signers must perform before accepting UTXO, script, and sighash data."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech Topic: PSBT",
+      "url": "https://bitcoinops.org/en/topics/psbt/",
+      "notes": "Implementation-oriented history of PSBT safety, interoperability, and signer behavior across wallet software and hardware devices."
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "psbt",
+    "signing",
+    "transaction verification"
+  ],
+  "aliases": [
+    "PSBT auditing",
+    "pre-signing PSBT checks",
+    "PSBT verification before signing"
+  ]
+}

--- a/content/nodes/extension.l402.json
+++ b/content/nodes/extension.l402.json
@@ -1,0 +1,41 @@
+{
+  "id": "extension.l402",
+  "title": "L402 Lightning HTTP Payments",
+  "description": "L402 combines an HTTP 402 challenge, a Lightning invoice, and a macaroon-based access token so a client can pay for an online resource and retry with cryptographic proof of payment. It enables metered APIs and machine-to-machine access without requiring a conventional account or credit-card session.",
+  "category": "Extension Systems",
+  "prerequisites": [
+    "lightning.invoices"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "L402 Protocol Specification",
+      "url": "https://docs.lightning.engineering/the-lightning-network/l402/protocol-specification",
+      "notes": "Official request, challenge, payment, and authenticated-retry flow, including token and preimage handling."
+    },
+    {
+      "type": "tool",
+      "title": "Lightning Labs L402 Repository",
+      "url": "https://github.com/lightninglabs/L402",
+      "notes": "Reference libraries and examples for adding L402 payment authentication to clients and servers."
+    },
+    {
+      "type": "article",
+      "title": "Freedom Skills: L402 API Reference",
+      "url": "https://github.com/brenorb/freedom-skills/blob/main/skills/mdk-l402-api/references/l402-api.md",
+      "notes": "Practical guide to the L402 challenge-response flow and common security checks when integrating a paid API."
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "lightning",
+    "payments",
+    "authentication"
+  ],
+  "aliases": [
+    "Lightning Service Authentication Token",
+    "LSAT",
+    "HTTP 402 Lightning payments",
+    "Lightning paid APIs"
+  ]
+}

--- a/content/nodes/history.2013-chain-split.json
+++ b/content/nodes/history.2013-chain-split.json
@@ -1,0 +1,41 @@
+{
+  "id": "history.2013-chain-split",
+  "title": "March 2013 Chain Split",
+  "description": "Bitcoin Core 0.8 accepted a block that older 0.7 nodes rejected because the versions used different databases with different practical limits. The accidental split showed that undocumented implementation constraints can become de facto consensus rules and that recovery may require miners and users to coordinate around compatibility.",
+  "category": "History & Governance",
+  "prerequisites": [
+    "protocol.softfork-hardfork"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 50: March 2013 Chain Fork Post-Mortem",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0050.mediawiki",
+      "notes": "Canonical post-mortem covering the Berkeley DB lock limit, the LevelDB transition, the split, and the coordinated recovery."
+    },
+    {
+      "type": "article",
+      "title": "11/12 March 2013 Chain Fork Information",
+      "url": "https://bitcoin.org/chainfork",
+      "notes": "Contemporaneous public notice explaining which node versions followed each chain and why major miners temporarily returned to 0.7 compatibility."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core 0.8.0 Release Notes",
+      "url": "https://bitcoin.org/en/release/v0.8.0",
+      "notes": "Documents the chain database migration from Berkeley DB to LevelDB that exposed the compatibility boundary."
+    }
+  ],
+  "estimatedTime": "35m",
+  "tags": [
+    "history",
+    "consensus",
+    "chain splits"
+  ],
+  "aliases": [
+    "2013 chain fork",
+    "BIP 50",
+    "Bitcoin Core 0.8 fork",
+    "Berkeley DB chain split"
+  ]
+}

--- a/content/nodes/protocol.byte-order.json
+++ b/content/nodes/protocol.byte-order.json
@@ -9,15 +9,15 @@
   "resources": [
     {
       "type": "article",
-      "title": "Learn Me a Bitcoin: Byte Order",
-      "url": "https://learnmeabitcoin.com/technical/general/byte-order/",
-      "notes": "Practical explanation of little-endian serialization and reversed hash display."
+      "title": "Bitcoin Developer Reference: Block Headers",
+      "url": "https://developer.bitcoin.org/reference/block_chain.html#block-headers",
+      "notes": "Field-level reference showing little-endian header integers and the internal-versus-displayed hash byte-order convention."
     },
     {
       "type": "article",
-      "title": "Learn Me a Bitcoin: Little Endian",
-      "url": "https://learnmeabitcoin.com/technical/general/little-endian/",
-      "notes": "Concrete examples of converting numbers and byte sequences in Bitcoin data."
+      "title": "Bitcoin Wiki: Protocol Documentation",
+      "url": "https://en.bitcoin.it/wiki/Protocol_documentation#Common_structures",
+      "notes": "Wire-protocol reference for little-endian integers, hashes, and other common serialized structures."
     },
     {
       "type": "book",
@@ -43,4 +43,3 @@
     "hash byte order"
   ]
 }
-

--- a/content/nodes/protocol.compact-size-encoding.json
+++ b/content/nodes/protocol.compact-size-encoding.json
@@ -9,15 +9,15 @@
   "resources": [
     {
       "type": "article",
-      "title": "Learn Me a Bitcoin: Compact Size",
-      "url": "https://learnmeabitcoin.com/technical/general/compact-size/",
-      "notes": "Visual explanation of Bitcoin's variable-length integer format and decoding rules."
+      "title": "Bitcoin Wiki: Protocol Documentation",
+      "url": "https://en.bitcoin.it/wiki/Protocol_documentation#Variable_length_integer",
+      "notes": "Wire-protocol table for CompactSize prefixes, encoded widths, and integer ranges."
     },
     {
       "type": "article",
       "title": "Bitcoin Core Developer Documentation: Serialization",
-      "url": "https://developer.bitcoin.org/reference/transactions.html",
-      "notes": "Reference context for CompactSize fields in transaction serialization."
+      "url": "https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers",
+      "notes": "Reference context for CompactSize fields and canonical size encodings in transaction serialization."
     },
     {
       "type": "book",
@@ -42,4 +42,3 @@
     "var_int"
   ]
 }
-

--- a/content/nodes/protocol.sighash-single-bug.json
+++ b/content/nodes/protocol.sighash-single-bug.json
@@ -1,0 +1,34 @@
+{
+  "id": "protocol.sighash-single-bug",
+  "title": "Legacy SIGHASH_SINGLE Bug",
+  "description": "In legacy signature hashing, SIGHASH_SINGLE with an input index that has no matching output signs the constant value 1 instead of the intended transaction data. Because old signatures depend on that behavior, the bug remains part of legacy consensus even though newer signature algorithms reject or avoid the edge case.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.sighash-flags"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 143: Transaction Signature Verification for Version 0 Witness Program",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki",
+      "notes": "The specification documents the out-of-range SIGHASH_SINGLE behavior inherited from legacy signature hashing and how SegWit v0 handles output commitments."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Core: SignatureHash Implementation",
+      "url": "https://github.com/bitcoin/bitcoin/blob/a2e074d66ac17ca7907909bbbb563e77185a45e5/src/script/interpreter.cpp#L1610-L1621",
+      "notes": "Pinned consensus implementation showing the legacy out-of-range branch returning uint256::ONE while newer signature versions use different rules."
+    }
+  ],
+  "estimatedTime": "25m",
+  "tags": [
+    "sighash",
+    "consensus bugs",
+    "signatures"
+  ],
+  "aliases": [
+    "SIGHASH_SINGLE bug",
+    "SIGHASH_SINGLE out-of-range bug",
+    "SIGHASH_SINGLE constant one"
+  ]
+}

--- a/content/nodes/protocol.taproot-script-path-spends.json
+++ b/content/nodes/protocol.taproot-script-path-spends.json
@@ -1,0 +1,41 @@
+{
+  "id": "protocol.taproot-script-path-spends",
+  "title": "Taproot Script-Path Spends",
+  "description": "A Taproot script-path spend reveals one committed Tapscript leaf, the witness items that satisfy it, and a control block proving that leaf belongs to the output key. Nodes recompute the Taproot commitment before executing the revealed script, while every unused branch remains hidden.",
+  "category": "Protocol & Consensus",
+  "prerequisites": [
+    "protocol.taproot-control-blocks",
+    "protocol.tapscript"
+  ],
+  "resources": [
+    {
+      "type": "article",
+      "title": "BIP 341: Taproot",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki",
+      "notes": "Canonical witness and control-block rules for proving that a revealed script was committed by a P2TR output."
+    },
+    {
+      "type": "article",
+      "title": "BIP 342: Validation of Taproot Scripts",
+      "url": "https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki",
+      "notes": "Defines how the revealed Tapscript leaf is executed after its Taproot commitment has been verified."
+    },
+    {
+      "type": "article",
+      "title": "Bitcoin Optech Schnorr/Taproot Workshop",
+      "url": "https://bitcoinops.org/en/schnorr-taproot-workshop/",
+      "notes": "Worked exercises for constructing TapTrees and spending a selected branch with its inclusion proof."
+    }
+  ],
+  "estimatedTime": "30m",
+  "tags": [
+    "taproot",
+    "tapscript",
+    "spending"
+  ],
+  "aliases": [
+    "script path spend",
+    "taproot script spend",
+    "P2TR script path"
+  ]
+}


### PR DESCRIPTION
## Summary

Audits the linked Delving Bitcoin discussion, its Bitcoin Wizard benchmark, linked books, and implementation references against the existing learning graph.

Adds five distinct learner-facing concepts:

- PSBT signer validation
- L402 Lightning HTTP payments
- March 2013 chain split
- legacy SIGHASH_SINGLE bug
- Taproot script-path spends

The audit excluded or deferred topics already represented by existing nodes, broad source collections, implementation projects, and umbrella questions. Examples include AssumeUTXO, OP_CHECKMULTISIG, CSV, SegWit block weight, secp256k1 parameters, P2PK rendering, and generic grandfathered-consensus rules.

Also replaces three pre-existing serialization resource URLs that returned 403 and blocked the repository-wide CI link check.

## Verification

- `npm test` — 19 files, 109 tests passed
- `npm run build` — production build passed
- `npm run check:links` — 499 unique URLs checked; all reachable
- `git diff --check origin/master...HEAD` — passed

No node-specific ceremonial tests were added because this is a pure content change; the existing schema, reference, cycle, prerequisite-redundancy, build, and link checks cover the relevant invariants.